### PR TITLE
Mention SCSS linting in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,17 @@ Enable the linter in the VS Code [settings](https://code.visualstudio.com/docs/c
 }
 ```
 
+If you plan to use stylelint also for linting SCSS files, you should also disable the build-in SCSS linter:
+
+```json
+{
+  "stylelint.enable": true,
+  "css.validate": false,
+  "scss.validate": false
+}
+```
+
+
 ### Configurations
 
 *In addition to the VS Code settings mentioned below, you can set the config by adding [stylelint configuration files](https://github.com/stylelint/stylelint/blob/master/docs/user-guide/configuration.md#configuration) to the workspace directory.*

--- a/README.md
+++ b/README.md
@@ -17,16 +17,7 @@ See the [extension installation guide](https://code.visualstudio.com/docs/editor
 
 ## Usage
 
-Enable the linter in the VS Code [settings](https://code.visualstudio.com/docs/customization/userandworkspace), while disabling the built-in CSS linter:
-
-```json
-{
-  "stylelint.enable": true,
-  "css.validate": false
-}
-```
-
-If you plan to use stylelint also for linting SCSS files, you should also disable the build-in SCSS linter:
+Enable the linter in the VS Code [settings](https://code.visualstudio.com/docs/customization/userandworkspace), while disabling the built-in CSS and SCSS linter:
 
 ```json
 {
@@ -35,7 +26,6 @@ If you plan to use stylelint also for linting SCSS files, you should also disabl
   "scss.validate": false
 }
 ```
-
 
 ### Configurations
 


### PR DESCRIPTION
As stylelint is also suitable (and meant) for linting SCSS, I added the step to disable the built-in SCSS linter.